### PR TITLE
hashicorp/mdns not maintained, change to fork repo

### DIFF
--- a/homecast.go
+++ b/homecast.go
@@ -10,7 +10,7 @@ import (
 	"github.com/barnybug/go-cast"
 	"github.com/barnybug/go-cast/controllers"
 	castnet "github.com/barnybug/go-cast/net"
-	"github.com/hashicorp/mdns"
+	"github.com/micro/mdns"
 )
 
 const (


### PR DESCRIPTION
Hi, commiters :)

in my environment, mdns can't bind ports.
I found this [issue](https://github.com/hashicorp/mdns/issues/51).
hashicorp/mdns is maybe not maintained.

This PR is changed forked repository to https://github.com/micro/mdns .
As far as I can see, it's fine works.